### PR TITLE
Adds `NewDefault` to simplify usage 

### DIFF
--- a/default.go
+++ b/default.go
@@ -1,0 +1,120 @@
+package slogassert
+
+import (
+	"log"
+	"log/slog"
+	"os"
+	"testing"
+)
+
+// config is used to configure the default handler, and allow the
+// use of functional options.
+type config struct {
+	level       slog.Leveler
+	assertEmpty bool
+	wrapped     slog.Handler
+}
+
+// An Option allows for configuration of the default handler created
+// by [NewDefault].
+type Option func(*config)
+
+// WithLeveler is a functional option for [NewDefault] that sets the
+// minimum log level of the default handler.
+// All messages below this level will be ignored.
+func WithLeveler(level slog.Leveler) Option {
+	return func(c *config) {
+		c.level = level
+	}
+}
+
+// WithAssertEmpty is a functional option for [NewDefault] that configures
+// the handler to validated that all messages have been captured and
+// asserted.
+func WithAssertEmpty() Option {
+	return func(c *config) {
+		c.assertEmpty = true
+	}
+}
+
+// WithWrapped is a functional option for [NewDefault] that wraps the
+// generated default handler with another handler.
+// If set then handle calls will be passed down to that
+// handler as well.
+func WithWrapped(wrapped slog.Handler) Option {
+	return func(c *config) {
+		c.wrapped = wrapped
+	}
+}
+
+// NewDefault is a helper function for tests that creates a slogassert [Handler]
+// and sets it as the default slog handler
+// Once the test is complete it will attempt to restore the previous handler.
+//
+// It accepts options to customize the handler, including
+//   - [WithLeveler] to set the log level
+//   - [WithAssertEmpty] to assert that the handler is empty at the end of the test
+//   - [WithWrapped] to wrap the handler with another handler
+//
+// Example:
+//
+//	func TestExample(t *testing.T) {
+//		handler := NewDefault(t, WithLeveler(slog.LevelError))
+//
+//	 	CodeUnderTest()
+//
+//	 	handler.AssertMessage("expected log message")
+//	}
+//
+// This function MUST NOT be used with t.Parallel(). Doing so will cause unexpected
+// results.
+func NewDefault(t testing.TB, opts ...Option) *Handler {
+	// config used to allow for functional options
+	c := config{
+		level:       slog.LevelDebug,
+		assertEmpty: false,
+		wrapped:     nil,
+	}
+
+	for _, opt := range opts {
+		opt(&c)
+	}
+
+	handler := New(t, c.level, c.wrapped)
+
+	// take a copy of the original logger and flags so that we can restore
+	// once the test is complete
+	origLogger := slog.Default()
+	origFlags := log.Flags()
+
+	t.Cleanup(func() {
+		// if WithAssertEmpty was set, then ensure that all messages
+		// have been captured.
+		if c.assertEmpty {
+			handler.AssertEmpty()
+		}
+
+		// if the original logger was a default logger, then slog does not
+		// allow full restoration as this would cause a race condition.
+		// Instead, we attempt to manually  restore.
+		// This may cause unexpected results if the output of the default
+		// logged had been set to something other than stdout.
+		// This is unlikely to have happened during test flows, and would
+		// also be unlikely to cause problems in tests if it has happened.
+		log.SetOutput(os.Stdout)
+		log.SetFlags(origFlags)
+
+		// if the original logger was not a default logger, then we can
+		// safely restore it.
+		slog.SetDefault(origLogger)
+	})
+
+	// create a new logger with the slogassert handler, and set it as the
+	// default logger
+	logger := slog.New(handler)
+	slog.SetDefault(logger)
+
+	// the slogassert handler is returned to allow for tests to validate log
+	//messages
+	return handler
+}

--- a/default_test.go
+++ b/default_test.go
@@ -1,0 +1,104 @@
+package slogassert_test
+
+import (
+	"context"
+	"github.com/thejerf/slogassert"
+	"log/slog"
+	"testing"
+)
+
+// fakeTestingT is a testing.T used in the runnable example to demostrate usage
+type fakeTestingT struct {
+	*testing.T
+}
+
+func (ft *fakeTestingT) Run(_ string, f func(t *testing.T)) {
+	f(ft.T)
+}
+
+var t = &fakeTestingT{
+	T: &testing.T{},
+}
+
+// CodeUnderTest is an example function, used to demonstrate usage.
+func CodeUnderTest() {
+	slog.ErrorContext(context.Background(), "expected log message")
+}
+
+// --
+
+func ExampleNewDefault() {
+	t.Run("ensure correct slog message is written", func(t *testing.T) {
+		// update the default logger, and then reset it at the end of the test
+		st := slogassert.NewDefault(
+			t,
+			slogassert.WithLeveler(slog.LevelInfo), // only capture info and above
+			slogassert.WithAssertEmpty(),           // ensure that all messages have been captured
+		)
+
+		// ...
+		// run the test code
+
+		CodeUnderTest()
+
+		// ...
+
+		// capture and assert that the logged message
+		st.AssertMessage("expected log message")
+	})
+
+	// Output:
+}
+
+// --
+
+func Test_NewDefault(t *testing.T) {
+	t.Run("With default slog handler", func(t *testing.T) {
+		defaultHandler := slogassert.NewDefault(t)
+
+		slog.Info("This should be captured")
+		slog.Info("This should be ignored")
+
+		defaultHandler.AssertMessage("This should be captured")
+	})
+
+	t.Run("With custom slog handler", func(t *testing.T) {
+		handler := slogassert.New(t, slog.LevelDebug, nil)
+		slog.SetDefault(slog.New(handler))
+
+		t.Run("subtest", func(t *testing.T) {
+			defaultHandler := slogassert.NewDefault(t)
+			slog.Info("This should be captured")
+			slog.Info("This should be ignored")
+
+			defaultHandler.AssertMessage("This should be captured")
+		})
+
+		slog.Info("This should also be captured")
+		handler.AssertMessage("This should also be captured")
+	})
+
+	t.Run("With wrapped logger", func(t *testing.T) {
+		handler := slogassert.New(t, slog.LevelDebug, nil)
+		defaultHandler := slogassert.NewDefault(t, slogassert.WithWrapped(handler))
+
+		slog.Info("This should be captured")
+
+		handler.AssertMessage("This should be captured")
+		defaultHandler.AssertMessage("This should be captured")
+	})
+
+	t.Run("With leveler", func(t *testing.T) {
+		defaultHandler := slogassert.NewDefault(
+			t,
+			slogassert.WithLeveler(slog.LevelInfo),
+			slogassert.WithAssertEmpty(),
+		)
+
+		slog.Debug("This should be ignored")
+		slog.Info("This should be captured")
+
+		defaultHandler.AssertMessage("This should be captured")
+	})
+
+}

--- a/slogassert.go
+++ b/slogassert.go
@@ -60,7 +60,7 @@ type Handler struct {
 	m           sync.Mutex
 	logMessages []LogMessage
 
-	t *testing.T
+	t testing.TB
 }
 
 // New creates a new testing logger, logging with the given level.
@@ -70,7 +70,7 @@ type Handler struct {
 //
 // It is recommended to generally call defer handler.AssertEmpty() on
 // the result of this call.
-func New(t *testing.T, leveler slog.Leveler, wrapped slog.Handler) *Handler {
+func New(t testing.TB, leveler slog.Leveler, wrapped slog.Handler) *Handler {
 	if t == nil {
 		panic("t must not be nil for a slogtest.Handler")
 	}


### PR DESCRIPTION
Adds a simple wrapper to `slogassert` to simplify testing code:

Example:
```
	func TestExample(t *testing.T) {
		handler := NewDefault(t, WithLeveler(slog.LevelError))
	 	slog.Error("Test message")
	 	handler.AssertMessage("Test message")
	}
```